### PR TITLE
Version in Swagger fix

### DIFF
--- a/src/RestApi.Example/Utils/Swagger/ConfigureSwaggerGenOptions.cs
+++ b/src/RestApi.Example/Utils/Swagger/ConfigureSwaggerGenOptions.cs
@@ -51,14 +51,7 @@ namespace RestApi.Example.Utils.Swagger
         {
             foreach (var description in provider.ApiVersionDescriptions)
             {
-                settings.Info.Version = description.ApiVersion.ToString();
-
-                if (description.IsDeprecated)
-                {
-                    settings.Info.Description += " - DEPRECATED";
-                }
-
-                options.SwaggerDoc(description.GroupName, settings.Info);
+                options.SwaggerDoc(description.GroupName, settings.GetOpenApiInfo(description.ApiVersion.ToString(), description.IsDeprecated));
             }
         }
 

--- a/src/RestApi.Example/Utils/Swagger/SwaggerSettings.cs
+++ b/src/RestApi.Example/Utils/Swagger/SwaggerSettings.cs
@@ -14,22 +14,38 @@ namespace RestApi.Example.Utils.Swagger
         public SwaggerSettings()
         {
             Name = "REST API Example";
-            Info = new OpenApiInfo
-            {
-                Title = "REST API Example",
-                Description = "REST API Versions"                
-            };
+            Title = "REST API Example";
+            Description = "REST API Versions";
+
         }
+
+        /// <summary>
+        /// Gets or sets Title.
+        /// </summary>
+        public string Title { get;  }
+
+        /// <summary>
+        /// Gets or sets Description.
+        /// </summary>
+        public string Description { get; }
 
         /// <summary>
         /// Gets or sets document Name.
         /// </summary>
-        public string Name { get; set; }
+        public string Name { get; }
 
         /// <summary>
         /// Gets or sets swagger Info.
         /// </summary>
-        public OpenApiInfo Info { get; set; }
+        public OpenApiInfo GetOpenApiInfo(string version, bool isDeprecated)
+        {
+            return new OpenApiInfo
+            {
+                Description = Description + (isDeprecated ? " - DEPRECATED" : ""),
+                Title = Title,
+                Version = version
+            };
+        }
 
         /// <summary>
         /// Gets or sets RoutePrefix.


### PR DESCRIPTION
For all the versions there is only one instance of openapiinfo so the version in Swagger is for all the version taken from the last iteration.